### PR TITLE
Remove phpunit whitelist option from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ php:
 
 before_install: pip install --user codecov
 install: travis_retry composer install --no-interaction --prefer-source
-script: vendor/bin/phpunit --configuration phpunit.xml --coverage-clover clover.xml --whitelist src
+script: vendor/bin/phpunit --configuration phpunit.xml --coverage-clover clover.xml
 after_success: codecov


### PR DESCRIPTION
The whitelist is already defined in the phpunit.xml file (loaded with `--configuration phpunit.xml`).